### PR TITLE
Create themed FMX screens

### DIFF
--- a/appMobileSiscont.dpr
+++ b/appMobileSiscont.dpr
@@ -10,6 +10,8 @@ uses
   ProductsForm in 'src\ProductsForm.pas' {frmProducts},
   LoginForm in 'src\LoginForm.pas' {frmLogin},
   SplashForm in 'src\SplashForm.pas' {frmSplash},
+  AppStyle in 'src\AppStyle.pas' {dmStyle: TDataModule},
+  BudgetForm in 'src\BudgetForm.pas' {frmBudget},
   DataModule in 'src\DataModule.pas' {dmData: TDataModule};
 
 {$R *.res}
@@ -19,10 +21,12 @@ begin
   Application.CreateForm(TfrmMain, frmMain);
   Application.CreateForm(TfrmLogin, frmLogin);
   Application.CreateForm(TfrmSplash, frmSplash);
+  Application.CreateForm(TdmStyle, dmStyle);
   Application.CreateForm(TfrmProducts, frmProducts);
   Application.CreateForm(TfrmProductEdit, frmProductEdit);
   Application.CreateForm(TfrmClients, frmClients);
   Application.CreateForm(TfrmClientEdit, frmClientEdit);
+  Application.CreateForm(TfrmBudget, frmBudget);
   Application.CreateForm(TdmData, dmData);
   Application.Run;
 end.

--- a/src/AppStyle.dfm
+++ b/src/AppStyle.dfm
@@ -1,0 +1,4 @@
+object dmStyle: TdmStyle
+  object StyleBook1: TStyleBook
+  end
+end

--- a/src/AppStyle.pas
+++ b/src/AppStyle.pas
@@ -1,0 +1,24 @@
+unit AppStyle;
+
+interface
+
+uses
+  System.SysUtils, System.Classes, FMX.Types, FMX.Styles;
+
+type
+  TdmStyle = class(TDataModule)
+    StyleBook1: TStyleBook;
+  private
+  public
+  end;
+
+var
+  dmStyle: TdmStyle;
+
+implementation
+
+{%CLASSGROUP 'FMX.Controls.TControl'}
+
+{$R *.dfm}
+
+end.

--- a/src/BudgetForm.fmx
+++ b/src/BudgetForm.fmx
@@ -1,0 +1,20 @@
+object frmBudget: TfrmBudget
+  Caption = 'Orcamento'
+  object SegmentedControl1: TSegmentedControl
+    Align = Top
+    Width = 300
+    Position.X = 10
+    Position.Y = 10
+    SegmentCount = 3
+  end
+  object rectChart: TRectangle
+    Align = Top
+    Height = 160
+    Margins.Top = 10
+    Fill.Color = claWhite
+  end
+  object LayoutIcons: TLayout
+    Align = Client
+    Margins.Top = 10
+  end
+end

--- a/src/BudgetForm.pas
+++ b/src/BudgetForm.pas
@@ -1,0 +1,35 @@
+unit BudgetForm;
+
+interface
+
+uses
+  System.SysUtils, System.Types, System.UITypes, System.Classes, System.Variants,
+  FMX.Types, FMX.Controls, FMX.Forms, FMX.StdCtrls, FMX.SegmentedControl,
+  FMX.Objects, FMX.Layouts, Theme;
+
+type
+  TfrmBudget = class(TForm)
+    SegmentedControl1: TSegmentedControl;
+    rectChart: TRectangle;
+    LayoutIcons: TLayout;
+    procedure FormCreate(Sender: TObject);
+  private
+  public
+  end;
+
+var
+  frmBudget: TfrmBudget;
+
+implementation
+
+{$R *.fmx}
+
+procedure TfrmBudget.FormCreate(Sender: TObject);
+begin
+  ApplyTheme(Self);
+  SegmentedControl1.Items[0].Text := 'Mensal';
+  SegmentedControl1.Items[1].Text := 'Semanal';
+  SegmentedControl1.Items[2].Text := 'Di\u00e1rio';
+end;
+
+end.

--- a/src/ClientEditForm.fmx
+++ b/src/ClientEditForm.fmx
@@ -1,22 +1,47 @@
 object frmClientEdit: TfrmClientEdit
-  object ToolBar1: TToolBar
-  end
-  object lblEditClient: TLabel
-  end
-  object edtNome: TEdit
-  end
-  object edtDocumento: TEdit
-  end
-  object edtEndereco: TEdit
-  end
-  object edtMunicipio: TEdit
-  end
-  object cmbUF: TComboBox
-  end
-  object edtCEP: TEdit
-  end
-  object edtTelefone: TEdit
+  Caption = 'Cadastro Cliente'
+  object ScrollBox1: TScrollBox
+    Align = Client
+    Padding.Left = 16
+    Padding.Right = 16
+    object edtNome: TEdit
+      Align = Top
+      TextPrompt = 'Nome'
+    end
+    object edtDocumento: TEdit
+      Align = Top
+      Margins.Top = 10
+      TextPrompt = 'Documento'
+    end
+    object edtEndereco: TEdit
+      Align = Top
+      Margins.Top = 10
+      TextPrompt = 'Endereço'
+    end
+    object edtMunicipio: TEdit
+      Align = Top
+      Margins.Top = 10
+      TextPrompt = 'Município'
+    end
+    object cmbUF: TComboBox
+      Align = Top
+      Margins.Top = 10
+      Width = 100
+      Items.Strings = ('AC','AL','AP','AM','BA','CE','DF','ES','GO','MA','MT','MS','MG','PA','PB','PR','PE','PI','RJ','RN','RS','RO','RR','SC','SP','SE','TO')
+    end
+    object edtCEP: TEdit
+      Align = Top
+      Margins.Top = 10
+      TextPrompt = 'CEP'
+    end
+    object edtTelefone: TEdit
+      Align = Top
+      Margins.Top = 10
+      TextPrompt = 'Telefone'
+    end
   end
   object btnSave: TButton
+    Align = Bottom
+    Text = 'Salvar'
   end
 end

--- a/src/ClientEditForm.pas
+++ b/src/ClientEditForm.pas
@@ -5,12 +5,11 @@ interface
 uses
   System.SysUtils, System.Types, System.UITypes, System.Classes, System.Variants,
   FMX.Types, FMX.Controls, FMX.Forms, FMX.Dialogs, FMX.StdCtrls, FMX.Edit,
-  FMX.Controls.Presentation, FMX.ListBox, Theme;
+  FMX.Controls.Presentation, FMX.ListBox, FMX.ScrollBox, Theme;
 
 type
   TfrmClientEdit = class(TForm)
-    ToolBar1: TToolBar;
-    lblEditClient: TLabel;
+    ScrollBox1: TScrollBox;
     edtNome: TEdit;
     edtDocumento: TEdit;
     edtEndereco: TEdit;
@@ -37,7 +36,6 @@ implementation
 procedure TfrmClientEdit.FormCreate(Sender: TObject);
 begin
   ApplyTheme(Self);
-  lblEditClient.Text := 'Cliente';
 end;
 
 procedure TfrmClientEdit.btnSaveClick(Sender: TObject);

--- a/src/LoginForm.fmx
+++ b/src/LoginForm.fmx
@@ -1,14 +1,37 @@
 object frmLogin: TfrmLogin
-  object ToolBar1: TToolBar
-  end
-  object lblTitle: TLabel
+  Caption = 'Login'
+  object RectGradient: TRectangle
+    Align = Bottom
+    Height = 200
+    Fill.Kind = Gradient
+    Fill.Gradient.Color = $FF3D8EFF
+    Fill.Gradient.Color1 = $FF0055D1
   end
   object edtUser: TEdit
+    Align = Top
+    Margins.Left = 20
+    Margins.Right = 20
+    TextPrompt = 'Nome'
   end
   object edtPassword: TEdit
+    Align = Top
+    Margins.Left = 20
+    Margins.Top = 10
+    Margins.Right = 20
+    Password = True
+    TextPrompt = 'Senha'
   end
   object btnLogin: TButton
+    Align = Top
+    Margins.Left = 20
+    Margins.Top = 20
+    Margins.Right = 20
+    Text = 'Log in'
   end
   object lblForgot: TLabel
+    Align = Top
+    Margins.Left = 20
+    Margins.Top = 10
+    Text = 'Forgot Password?'
   end
 end

--- a/src/LoginForm.pas
+++ b/src/LoginForm.pas
@@ -28,15 +28,23 @@ implementation
 
 {$R *.fmx}
 
+uses MainForm;
+
 procedure TfrmLogin.FormCreate(Sender: TObject);
 begin
   ApplyTheme(Self);
   lblTitle.Text := 'Login';
+  edtUser.TextPrompt := 'Nome';
+  edtPassword.TextPrompt := 'Senha';
+  edtPassword.Password := True;
+  lblForgot.Text := 'Forgot Password?';
+  lblForgot.TextSettings.FontColor := COLOR_BLUE_DARK;
 end;
 
 procedure TfrmLogin.btnLoginClick(Sender: TObject);
 begin
-  // TODO: validate login
+  // Ação simples de login - abre o menu principal
+  frmMain.Show;
 end;
 
 end.

--- a/src/MainForm.fmx
+++ b/src/MainForm.fmx
@@ -1,14 +1,35 @@
 object frmMain: TfrmMain
+  Caption = 'Menu Principal'
   object ToolBar1: TToolBar
+    Align = Top
+    object lblTitle: TLabel
+      Text = 'SISCONT'
+    end
   end
-  object lblTitle: TLabel
+  object cardBalance: TRectangle
+    Align = Top
+    Height = 120
+    Margins.Left = 16
+    Margins.Right = 16
+    YRadius = 12
+    XRadius = 12
+    object lblBalance: TLabel
+      Align = Center
+      Text = 'Saldo da Conta R$ 0,00'
+    end
+    object btnSend: TButton
+      Align = Left
+      Width = 100
+      Text = 'Enviar'
+    end
+    object btnReceive: TButton
+      Align = Right
+      Width = 100
+      Text = 'Receber'
+    end
   end
-  object btnNewProduct: TButton
-  end
-  object btnNewClient: TButton
-  end
-  object btnListProducts: TButton
-  end
-  object btnListClients: TButton
+  object ListView1: TListView
+    Align = Client
+    Margins.Top = 10
   end
 end

--- a/src/MainForm.pas
+++ b/src/MainForm.pas
@@ -4,21 +4,21 @@ interface
 
 uses
   System.SysUtils, System.Types, System.UITypes, System.Classes, System.Variants,
-  FMX.Types, FMX.Controls, FMX.Forms, FMX.Dialogs, FMX.StdCtrls, Theme;
+  FMX.Types, FMX.Controls, FMX.Forms, FMX.Dialogs, FMX.StdCtrls,
+  FMX.Objects, FMX.ListView.Types, FMX.ListView, Theme;
 
 type
   TfrmMain = class(TForm)
     ToolBar1: TToolBar;
     lblTitle: TLabel;
-    btnNewProduct: TButton;
-    btnNewClient: TButton;
-    btnListProducts: TButton;
-    btnListClients: TButton;
+    cardBalance: TRectangle;
+    lblBalance: TLabel;
+    btnSend: TButton;
+    btnReceive: TButton;
+    ListView1: TListView;
     procedure FormCreate(Sender: TObject);
-    procedure btnNewProductClick(Sender: TObject);
-    procedure btnNewClientClick(Sender: TObject);
-    procedure btnListProductsClick(Sender: TObject);
-    procedure btnListClientsClick(Sender: TObject);
+    procedure btnSendClick(Sender: TObject);
+    procedure btnReceiveClick(Sender: TObject);
   private
     { Private declarations }
   public
@@ -32,32 +32,23 @@ implementation
 
 {$R *.fmx}
 
-uses ProductsForm, ClientsForm, ProductEditForm, ClientEditForm;
+
 
 procedure TfrmMain.FormCreate(Sender: TObject);
 begin
   ApplyTheme(Self);
   lblTitle.Text := 'SISCONT';
+  lblBalance.Text := 'Saldo da Conta R$ 5.634,12';
 end;
 
-procedure TfrmMain.btnNewClientClick(Sender: TObject);
+procedure TfrmMain.btnSendClick(Sender: TObject);
 begin
-  frmClientEdit.ShowModal;
+  // Ação de envio de valores
 end;
 
-procedure TfrmMain.btnNewProductClick(Sender: TObject);
+procedure TfrmMain.btnReceiveClick(Sender: TObject);
 begin
-  frmProductEdit.ShowModal;
-end;
-
-procedure TfrmMain.btnListClientsClick(Sender: TObject);
-begin
-  frmClients.Show;
-end;
-
-procedure TfrmMain.btnListProductsClick(Sender: TObject);
-begin
-  frmProducts.Show;
+  // Ação de recebimento de valores
 end;
 
 end.

--- a/src/ProductEditForm.fmx
+++ b/src/ProductEditForm.fmx
@@ -1,20 +1,41 @@
 object frmProductEdit: TfrmProductEdit
-  object ToolBar1: TToolBar
-  end
-  object lblEditProduct: TLabel
-  end
-  object edtCodigo: TEdit
-  end
-  object edtNome: TEdit
-  end
-  object edtNCM: TEdit
-  end
-  object edtUnidade: TEdit
-  end
-  object edtValorCompra: TEdit
-  end
-  object edtValorVenda: TEdit
+  Caption = 'Cadastro Produto'
+  object ScrollBox1: TScrollBox
+    Align = Client
+    Padding.Left = 16
+    Padding.Right = 16
+    object edtCodigo: TEdit
+      Align = Top
+      TextPrompt = 'Código'
+    end
+    object edtNome: TEdit
+      Align = Top
+      Margins.Top = 10
+      TextPrompt = 'Nome'
+    end
+    object edtNCM: TEdit
+      Align = Top
+      Margins.Top = 10
+      TextPrompt = 'NCM'
+    end
+    object edtUnidade: TEdit
+      Align = Top
+      Margins.Top = 10
+      TextPrompt = 'Unidade'
+    end
+    object edtValorCompra: TEdit
+      Align = Top
+      Margins.Top = 10
+      TextPrompt = 'Valor Compra'
+    end
+    object edtValorVenda: TEdit
+      Align = Top
+      Margins.Top = 10
+      TextPrompt = 'Valor Venda'
+    end
   end
   object btnSave: TButton
+    Align = Bottom
+    Text = 'Salvar'
   end
 end

--- a/src/ProductEditForm.pas
+++ b/src/ProductEditForm.pas
@@ -5,12 +5,11 @@ interface
 uses
   System.SysUtils, System.Types, System.UITypes, System.Classes, System.Variants,
   FMX.Types, FMX.Controls, FMX.Forms, FMX.Dialogs, FMX.StdCtrls, FMX.Edit,
-  FMX.Controls.Presentation, Theme;
+  FMX.Controls.Presentation, FMX.ScrollBox, Theme;
 
 type
   TfrmProductEdit = class(TForm)
-    ToolBar1: TToolBar;
-    lblEditProduct: TLabel;
+    ScrollBox1: TScrollBox;
     edtCodigo: TEdit;
     edtNome: TEdit;
     edtNCM: TEdit;
@@ -36,7 +35,6 @@ implementation
 procedure TfrmProductEdit.FormCreate(Sender: TObject);
 begin
   ApplyTheme(Self);
-  lblEditProduct.Text := 'Produto';
 end;
 
 procedure TfrmProductEdit.btnSaveClick(Sender: TObject);

--- a/src/SplashForm.fmx
+++ b/src/SplashForm.fmx
@@ -1,10 +1,21 @@
 object frmSplash: TfrmSplash
+  Caption = 'Splash'
   object Layout1: TLayout
-  end
-  object Image1: TImage
-  end
-  object lblTitle: TLabel
-  end
-  object btnEnter: TButton
+    Align = Contents
+    object Image1: TImage
+      Align = Center
+      Width = 200
+      Height = 200
+    end
+    object lblTitle: TLabel
+      Align = Top
+      Text = 'SISCONT'
+      TextSettings.Font.Size = 24
+      TextSettings.FontColor = claWhite
+    end
+    object btnEnter: TButton
+      Align = Bottom
+      Text = 'Continuar'
+    end
   end
 end

--- a/src/SplashForm.pas
+++ b/src/SplashForm.pas
@@ -26,15 +26,24 @@ implementation
 
 {$R *.fmx}
 
+uses LoginForm;
+
 procedure TfrmSplash.FormCreate(Sender: TObject);
 begin
   ApplyTheme(Self);
   lblTitle.Text := 'Bem-vindo ao SISCONT';
+  // Fundo em degradê vertical azul-claro para azul-escuro
+  Self.Fill.Kind := TBrushKind.Gradient;
+  Self.Fill.Gradient.Color := COLOR_BLUE_LIGHT;
+  Self.Fill.Gradient.Color1 := COLOR_BLUE_DARK;
+  Self.Fill.Gradient.Style := TGradientStyle.Linear;
 end;
 
 procedure TfrmSplash.btnEnterClick(Sender: TObject);
 begin
-  // TODO: open login form
+  // Abre a tela de login
+  if Assigned(frmLogin) then
+    frmLogin.Show;
 end;
 
 end.

--- a/src/Theme.pas
+++ b/src/Theme.pas
@@ -3,15 +3,21 @@ unit Theme;
 interface
 
 uses
-  System.UITypes, FMX.Forms, FMX.StdCtrls, FMX.Types, FMX.Controls;
+  System.UITypes, FMX.Forms, FMX.StdCtrls, FMX.Types, FMX.Controls, FMX.Edit,
+  AppStyle;
 
 const
-  COLOR_PRIMARY      = $FF005FA3; // Azul royal
-  COLOR_SECONDARY    = $FFFFFFFF; // Branco
-  COLOR_HIGHLIGHT    = $FFFDB813; // Amarelo ouro
-  COLOR_BACKGROUND   = $FFF4F7FA; // Fundo claro
-  COLOR_TEXT_SECOND  = $FF5B5B5B; // Textos secundários
+  // Paleta de cores principal
+  COLOR_BLUE_LIGHT   = $FF3D8EFF; // Azul claro
+  COLOR_BLUE_DARK    = $FF0055D1; // Azul escuro
+  COLOR_ACCENT       = $FFFFAA00; // Laranja-accent
+  COLOR_WHITE        = $FFFFFFFF; // Branco
+  COLOR_GRAY_DARK    = $FF4A4A4A; // Cinza-escuro
 
+  BORDER_RADIUS      = 12;        // Raio padrão de bordas
+  SHADOW_COLOR       = $33000000; // Preto 20%
+
+// Aplica as cores definidas no tema para controles padrões do formulário
 procedure ApplyTheme(const Form: TCommonCustomForm);
 
 implementation
@@ -21,18 +27,25 @@ var
   I: Integer;
   C: TComponent;
 begin
+  if Assigned(dmStyle) then
+    Form.StyleBook := dmStyle.StyleBook1;
   if Form is TForm then
-    TForm(Form).Fill.Color := COLOR_BACKGROUND;
+    TForm(Form).Fill.Color := COLOR_WHITE;
 
   for I := 0 to Form.ComponentCount - 1 do
   begin
     C := Form.Components[I];
     if C is TToolBar then
-      TToolBar(C).TintColor := COLOR_PRIMARY
+      TToolBar(C).TintColor := COLOR_BLUE_DARK
     else if C is TButton then
-      TButton(C).TintColor := COLOR_HIGHLIGHT
+    begin
+      TButton(C).TintColor := COLOR_ACCENT;
+      TButton(C).TextSettings.FontColor := COLOR_WHITE;
+    end
     else if C is TLabel then
-      TLabel(C).TextSettings.FontColor := COLOR_PRIMARY;
+      TLabel(C).TextSettings.FontColor := COLOR_BLUE_DARK
+    else if C is TEdit then
+      TEdit(C).TextSettings.FontColor := COLOR_GRAY_DARK;
   end;
 end;
 


### PR DESCRIPTION
## Summary
- define a new color palette and theme helper
- redesign Splash screen with gradient background
- style Login screen and connect to main menu
- update Main form with balance card and transactions list
- add Budget form placeholder
- convert product and client forms to use scroll boxes
- include a global StyleBook and register it in the project

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b2bbe95308326867d2694bdd77f59